### PR TITLE
Load/save polygon functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ th, td {
   <tr>
     <td>
       <form name="upload">
-        <input type="file" accept=".poly" id="file" name="file">
+        <input type="file" accept=".poly" onclick="this.value=null;" id="file" name="file">
       </form>
     </td>
     <td>

--- a/index.html
+++ b/index.html
@@ -41,26 +41,65 @@ circle.guard {
   line-width:1px;
 }
 
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+  margin-left:auto;
+  margin-right:auto;
+  text-align: center;
+}
+
+table {
+margin-bottom: 10px;
+}
+
+th, td {
+  padding: 5px;
+}
+
 </style>
 </head>
 <body>
-<div id="help">
-Click inside the polygon to spawn new guards.<br>
-Click any existing guard or vertex to remove it.<br>
-Drag any point to move it, and shift-drag on a polygon vertex to add a new vertex.<br>
-Finally, click <a href="#" id="triangulater">here</a> to automatically triangulate the polygon<br>
-and place guards according to a 3-coloring of the triangulation.
-</div>
-<script src="//d3js.org/d3.v3.min.js"></script>
+  <div id="help">
+  Click inside the polygon to spawn new guards.<br>
+  Click any existing guard or vertex to remove it.<br>
+  Drag any point to move it, and shift-drag on a polygon vertex to add a new vertex.<br>
+  Finally, click <a href="#" id="triangulater">here</a> to automatically triangulate the polygon<br>
+  and place guards according to a 3-coloring of the triangulation.
+  </div>
+<br>
+<table>
+  <tr>
+    <th>📗 Read polygon from file</th>
+    <th>💾 Save polygon to file</th>
+  </tr>
+  <tr>
+    <td>
+      <form name="upload">
+        <input type="file" accept=".poly" id="file" name="file">
+      </form>
+    </td>
+    <td>
+      <form name="download">
+        <input type="button" value="Save" onclick="save_polygon()">
+      </form>
+    </td>
+  </tr>
+</table>
+<hr>
+
+<script src="https://d3js.org/d3.v3.min.js"></script>
 <script>
 
 var width = 960,
     height = 500;
 
-var polygon = [[300,300],[600, 300],[450, 450]];
+//var polygon = [[300,300],[600, 300],[450, 450]];
+var polygon = [[400,100],[700, 100],[550, 250]];
 var polygon_is_good = true;
 
-var guards = [[450,375]];
+//var guards = [[450,375]];
+var guards = [[550,175]];
 var guard_vis = [];
 
 var triangulation = [];
@@ -291,14 +330,14 @@ function generate_guard_vis(guard,poly){
     }
     if(trackVertex < 1) {
       visPoly.push([trackVertex*(guardRay[0]-guard[0])+guard[0],
-        trackVertex*(guardRay[1]-guard[1])+guard[1]]);  
+        trackVertex*(guardRay[1]-guard[1])+guard[1]]);
     }
     else if((ang1 > 0) && (ang2 > 0)) {
       visPoly.push([trackVertex*(guardRay[0]-guard[0])+guard[0],
         trackVertex*(guardRay[1]-guard[1])+guard[1]]);
       visPoly.push(guardRay);
     }
-  
+
     else if((ang1 < 0) && (ang2 < 0)) {
       visPoly.push(guardRay);
       visPoly.push([trackVertex*(guardRay[0]-guard[0])+guard[0],
@@ -308,7 +347,7 @@ function generate_guard_vis(guard,poly){
     else if((ang1 > 0) === (ang2 < 0)) {
       visPoly.push(guardRay);
     }
-    
+
   }
   return visPoly;
 
@@ -342,7 +381,7 @@ function trim_ear(poly){
       // and try a new candidate ear
       if ((j !== i - 1 &&
            j !== i &&
-           j !== i + 1 && 
+           j !== i + 1 &&
            check_inside(poly[j], maybe_ear)) ||
            maybe_ear_angle < 0) {
         break;
@@ -361,7 +400,7 @@ function trim_ear(poly){
 
 function triangulate_and_color(poly){
   // Returns [t, colorDict] where t is a set of
-  // triangles and colorDict is a mapping of 
+  // triangles and colorDict is a mapping of
   // colors to vertices of poly
 
   var copy = poly.slice();
@@ -434,7 +473,7 @@ function generate_triangulation_and_guard_pos(poly){
     // guards exactly on vertices
     var prevVertex = poly[(i - 1 + poly.length)%poly.length];
     var nextVertex = poly[(i + 1)%poly.length];
-    var bumpAngle = vector_angle(point[0] - prevVertex[0], point[1] - prevVertex[1], 
+    var bumpAngle = vector_angle(point[0] - prevVertex[0], point[1] - prevVertex[1],
                                  nextVertex[0] - point[0], nextVertex[1] - point[1]);
     bumpAngle = (bumpAngle + Math.PI)/2;
     var baseAngle = Math.atan2(point[1] - prevVertex[1], point[0] - prevVertex[0]);
@@ -496,7 +535,7 @@ function redraw(){
   guard_vis_path.exit().remove();
   guard_vis_path.enter().append("path").attr("class","guard_vis");
   guard_vis_path.attr("d", poly_d_fn);
-  
+
   polygon_verts = polygon_verts.data(polygon);
   polygon_verts.exit().remove();
   polygon_verts.enter().append("circle");
@@ -516,6 +555,53 @@ function redraw(){
 
 function poly_d_fn(d) {
   return "M" + d.join("L") + "Z";
+}
+////////
+
+// Fires whenever file is uploaded.
+document.getElementById('file').onchange = function() {
+  console.log("Reading polygon from file...");
+  if (this.files.length == 1) {
+    var file = this.files[0];
+    var reader = new FileReader();
+    reader.readAsText(file, "UTF-8");
+    reader.onload = function (evt) {
+      var poly_and_guards = evt.target.result.split("#");
+      polygon = JSON.parse(poly_and_guards[0]);
+      guards = JSON.parse(poly_and_guards[1]);
+      update();
+    }
+    reader.onerror = function (evt) {
+      console.log("Error reading file!")
+    }
+  }
+};
+
+// Fires whenever "Save" button is clicked
+function save_polygon() {
+  console.log("Saving polygon and guards...");
+  var text = JSON.stringify(polygon) + "#" + JSON.stringify(guards);
+  download(text, "polygon.poly", "text");
+}
+
+// Function to download data to a file
+// Src: https://stackoverflow.com/questions/13405129/javascript-create-and-save-file
+function download(data, filename, type) {
+  var file = new Blob([data], {type: type});
+  if (window.navigator.msSaveOrOpenBlob) // IE10+
+    window.navigator.msSaveOrOpenBlob(file, filename);
+  else { // Others
+    var a = document.createElement("a"),
+      url = URL.createObjectURL(file);
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(function() {
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+      }, 0);
+  }
 }
 
 </script>


### PR DESCRIPTION
My computational geometry professor (Prof. Joe Mitchell) is using this tool as an online learning utility for his students, and he had the idea to augment the tool with load/save functionality, so that he can distribute the same polygon "copy" to everyone, and students can share their own examples.

Post by professor:
>**Wish list for a change to the code**
>
>Several of you are playing with the software I showed (see https://github.com/hexahedria/math_198o_gallery ).
What occurs to me would be very helpful would be a change to the code that would allow:
(1) to save a polygon to a file
(2) to read a polygon back in from a file (so we could all do the same example...)
and eventually....
(3) to be able to change color from red to, say, blue, and mark 2 kinds of points: "red" guard points and "blue" witness points...

**Changes:**
- Added table (below help text) containing "load polygon from file" button and "save polygon to file" button.
- Added CSS rules to format added DOM elements.
- Added JS functions to support load/save functionality (bottom of file).
- Shifted default polygon vertices/guards positions up and to the right, to more closely center them on screen.
- My editor automatically truncates trailing white space, so I think that accounts for the remainder of the changes.

Polygons are simply serialized by turning the `polygon` and `guards` arrays into strings, and delimiting them with a "#" character.

As far as I've tested, this merge preserves all previous functionality.